### PR TITLE
Robustify time lookup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "git_copyright"
 description = "Add/update copyright notes based on git history"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license-file = "LICENSE-APACHE"
+name = "git_copyright"
 readme = "README.md"
 repository = "https://github.com/sgasse/git-copyright"
 
@@ -20,10 +20,10 @@ chrono = "0.4.19"
 clap = { version = "3.0.14", features = ["derive"] }
 env_logger = "^0.9.0"
 futures = "0.3"
-git2 = { version = "0.13.25", default-features = false }
 glob = "^0.3.0"
 log = "^0.4.14"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.8"
 tokio = { version = "1", features = ["full"] }
+thiserror = "1.0.30"

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -12,7 +12,7 @@ pub async fn check_and_fix_file(
     years: String,
     copyright_line: String,
 ) {
-    // This could be re-written to read the file asynchronously until EOF of the first n
+    // This could be re-written to read the file asynchronously until EOF or the first n
     // newlines are found.
     let file = std::fs::File::open(&filepath)
         .expect(&format!("Could not open file {}", filepath.display()));

--- a/src/git_ops.rs
+++ b/src/git_ops.rs
@@ -1,206 +1,98 @@
 //! Extract added/modified times from git history.
 //!
-//! This is built on top of libgit2. Renames are followed.
 
-use super::AddedModifiedInfo;
-use chrono::DateTime;
-use chrono::{TimeZone, Utc};
-use git2::{Commit, Diff, DiffFile, Repository, TreeWalkMode, TreeWalkResult};
-use git2::{DiffFindOptions, Error};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use crate::AddedModifiedYears;
+use crate::CheckCopyrightError;
+use chrono::Utc;
+use futures::future::join_all;
+use std::path::Path;
+use tokio::process::Command;
 
 /// Get all files in repository on given `refname`.
-pub fn get_files_on_ref(
-    repo: &Repository,
-    refname: &str,
-    repopath: &str,
-) -> Result<Vec<String>, Error> {
-    let ref_id = repo.refname_to_id(refname)?;
-    let commit = repo.find_commit(ref_id)?;
-    let tree = commit.tree()?;
-    let mut files: Vec<String> = vec![];
-    tree.walk(TreeWalkMode::PreOrder, |root, entry| {
-        if let Some(filename) = entry.name() {
-            let path_in_repo = Path::new(root).join(Path::new(filename));
-            if Path::new(repopath).join(&path_in_repo).is_file() {
-                files.push(String::from(path_in_repo.to_str().unwrap()));
+pub async fn get_files_on_ref(
+    repo_path: &str,
+    ref_name: &str,
+) -> Result<Vec<String>, CheckCopyrightError> {
+    let output = Command::new("git")
+        .arg("ls-tree")
+        .arg("-r")
+        .arg(ref_name)
+        .arg("--name-only")
+        .current_dir(repo_path)
+        .output();
+
+    let output = output.await?;
+
+    // TODO: Handle error case
+
+    let output = std::str::from_utf8(&output.stdout).expect("Could not decode command output");
+    Ok(output
+        .split('\n')
+        .filter_map(|s| {
+            let s = s.to_owned();
+            match s.len() {
+                0 => None,
+                _ => Some(s),
             }
-        }
-        TreeWalkResult::Ok
-    })?;
-
-    Ok(files)
-}
-
-pub fn get_add_mod_ranges<'a>(
-    repo: &'a Repository,
-    files_to_check: impl Iterator<Item = &'a String>,
-) -> Result<Vec<AddedModifiedInfo>, Error> {
-    let mut unclear_add_mod = init_unclear_add_mod(files_to_check);
-    let mut add_mod_ranges: Vec<AddedModifiedInfo> = vec![];
-
-    let mut revwalk = repo.revwalk()?;
-    revwalk.set_sorting(git2::Sort::TIME)?;
-    revwalk.push_head()?;
-
-    // Tracking the last commit is necessary to handle files added in the first commit
-    let mut last_commit: Option<Commit> = None;
-
-    // Walk the commit tree until we have clarified the added/modified times
-    // of all files to check
-    while !unclear_add_mod.is_empty() {
-        last_commit = match revwalk.next() {
-            Some(Ok(commit_id)) => {
-                let commit = repo.find_commit(commit_id)?;
-                if commit.parent_count() == 1 {
-                    let mut diff = diff_to_prev(&repo, &commit)?;
-
-                    // Check for renames/copies
-                    diff.find_similar(Some(DiffFindOptions::new().all(true)))?;
-
-                    for delta in diff.deltas() {
-                        let new_file = delta.new_file();
-                        update_last_modified(&new_file, &commit, &mut unclear_add_mod)?;
-
-                        let old_file = delta.old_file();
-                        check_and_close_file_added(
-                            &old_file,
-                            &commit,
-                            &mut unclear_add_mod,
-                            &mut add_mod_ranges,
-                        )?;
-
-                        track_rename(&new_file, &old_file, &mut unclear_add_mod)?;
-                    }
-                }
-
-                Some(commit)
-            }
-            Some(Err(_)) => {
-                println!("Error finding a commit during revparse!");
-                None
-            }
-            None => {
-                // No parents - first commit reached
-                let first_commit_ts = to_utc(last_commit.unwrap().time());
-                for (_, mut add_mod_entry) in unclear_add_mod.drain() {
-                    add_mod_entry.added = Some(first_commit_ts.clone());
-                    add_mod_ranges.push(add_mod_entry);
-                }
-                None
-            }
-        };
-    }
-    Ok(add_mod_ranges)
-}
-
-fn check_and_close_file_added(
-    old_file: &DiffFile,
-    commit: &Commit,
-    unclear_add_mod: &mut HashMap<PathBuf, AddedModifiedInfo>,
-    add_mod_ranges: &mut Vec<AddedModifiedInfo>,
-) -> Result<(), Error> {
-    let file_path = old_file.path().unwrap();
-    if let Some(add_mod_entry) = unclear_add_mod.get(file_path) {
-        if !old_file.exists() {
-            let added_ts = to_utc(commit.time());
-            log::debug!("File {} was added on {:#?}", file_path.display(), added_ts);
-
-            add_mod_ranges.push(AddedModifiedInfo {
-                added: Some(added_ts),
-                last_modified: add_mod_entry.last_modified,
-                original_path: add_mod_entry.original_path.clone(), // TODO: Replace clone
-            });
-
-            unclear_add_mod.remove(file_path);
-        }
-    }
-    Ok(())
-}
-
-fn track_rename(
-    new_file: &DiffFile,
-    old_file: &DiffFile,
-    unclear_add_mod: &mut HashMap<PathBuf, AddedModifiedInfo>,
-) -> Result<(), Error> {
-    let new_file_path = new_file.path().unwrap();
-    let old_file_path = old_file.path().unwrap();
-    if new_file_path != old_file_path {
-        // File was renamed - try to remove and reinsert with name before rename
-        match unclear_add_mod.remove(new_file_path) {
-            Some(add_mod_entry) => {
-                unclear_add_mod.insert(old_file_path.to_path_buf(), add_mod_entry);
-            }
-            None => {
-                log::warn!(
-                    "Could not find {} to track rename to {}",
-                    new_file_path.display(),
-                    old_file_path.display()
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
-fn update_last_modified(
-    new_file: &DiffFile,
-    commit: &Commit,
-    unclear_add_mod: &mut HashMap<PathBuf, AddedModifiedInfo>,
-) -> Result<(), Error> {
-    let file_path = new_file.path().unwrap();
-    if let Some(add_mod_entry) = unclear_add_mod.get(file_path) {
-        // Path is still not clarified
-        let file_mod_time = to_utc(commit.time());
-        match add_mod_entry.last_modified {
-            Some(last_modified) if last_modified > file_mod_time => return Ok(()),
-            _ => {
-                let updated_entry = AddedModifiedInfo {
-                    added: None,
-                    last_modified: Some(file_mod_time),
-                    original_path: add_mod_entry.original_path.clone(),
-                };
-                unclear_add_mod.insert(file_path.to_path_buf(), updated_entry);
-
-                log::debug!(
-                    "Updated last_modified of file {} to {:#?}",
-                    file_path.display(),
-                    file_mod_time
-                );
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn init_unclear_add_mod<'a>(
-    files: impl Iterator<Item = &'a String>,
-) -> HashMap<PathBuf, AddedModifiedInfo> {
-    files
-        .map(|filename| {
-            let file_path = Path::new(filename);
-            (
-                file_path.to_path_buf(),
-                AddedModifiedInfo {
-                    added: None,
-                    last_modified: None,
-                    original_path: file_path.to_path_buf(),
-                },
-            )
         })
-        .collect::<HashMap<_, _>>()
+        .collect())
 }
 
-fn diff_to_prev<'a>(repo: &'a Repository, commit: &Commit) -> Result<Diff<'a>, Error> {
-    let tree = commit.tree()?;
-    let prev_commit = commit.parent(0)?;
-    let prev_tree = prev_commit.tree()?;
-
-    Ok(repo.diff_tree_to_tree(Some(&prev_tree), Some(&tree), None)?)
+pub async fn get_add_mod_ranges<'a>(
+    files_to_check: impl Iterator<Item = &'a String>,
+    repo_path: &str,
+) -> Result<Vec<AddedModifiedYears>, CheckCopyrightError> {
+    let time_futures: Vec<_> = files_to_check
+        .map(|filepath| get_added_mod_times_for_file(filepath, repo_path))
+        .collect();
+    Ok(join_all(time_futures).await)
 }
 
-fn to_utc(g_time: git2::Time) -> DateTime<Utc> {
-    Utc.timestamp(g_time.seconds(), 0)
+async fn get_added_mod_times_for_file(filepath: &str, cwd: &str) -> AddedModifiedYears {
+    let output = Command::new("git")
+        .arg("log")
+        .arg("--follow")
+        .arg("-m")
+        .arg("--pretty=%ci")
+        .arg(filepath)
+        .current_dir(cwd)
+        .output();
+    let output = output.await.unwrap().stdout;
+    let commit_years: Vec<String> = std::str::from_utf8(&output)
+        .unwrap()
+        .split('\n')
+        .filter_map(|s| {
+            // Take only first four chars (the year) from strings that are longer than zero
+            let s = s.to_owned();
+            match s.len() {
+                0 => None,
+                _ => Some(s.chars().take(4).collect()),
+            }
+        })
+        .collect();
+
+    let years_string = match commit_years.len() {
+        0 => {
+            log::debug!("File {} is untracked, add current year", filepath);
+            Utc::now().date().format("%Y").to_string()
+        }
+        1 => {
+            log::debug!("File {} was only committed once", filepath);
+            commit_years[0].clone()
+        }
+        num_commits => {
+            log::debug!("File {} was modified {} times", filepath, num_commits);
+            let added = commit_years[commit_years.len() - 1].clone();
+            let last_modified = commit_years[0].clone();
+            match added == last_modified {
+                true => added,
+                false => format!("{}-{}", added, last_modified),
+            }
+        }
+    };
+
+    AddedModifiedYears {
+        original_path: Path::new(filepath).to_path_buf(),
+        years: years_string,
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,9 @@ pub mod file_ops;
 pub mod git_ops;
 pub mod regex_ops;
 
-use chrono::DateTime;
-use chrono::Datelike;
-use chrono::Utc;
 pub use config::Config;
 use file_ops::check_and_fix_file;
 use futures::future::join_all;
-use git2::Repository;
 use git_ops::{get_add_mod_ranges, get_files_on_ref};
 use regex_ops::CopyrightCache;
 use regex_ops::{generate_base_regex, generate_copyright_line};
@@ -21,6 +17,18 @@ use std::collections::HashMap;
 use std::hash::Hasher;
 use std::path::{Path, PathBuf};
 
+use thiserror::Error;
+
+/// CheckCopyrightError enumerates possible errors returned by this library.
+#[derive(Error, Debug)]
+pub enum CheckCopyrightError {
+    #[error("No comment sign found for file/extension")]
+    NoCommentSign,
+
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+}
+
 #[derive(Debug, Deserialize, Hash, PartialEq)]
 #[serde(untagged)]
 pub enum CommentSign {
@@ -29,21 +37,28 @@ pub enum CommentSign {
 }
 
 #[derive(Debug)]
-pub struct AddedModifiedInfo {
-    pub added: Option<DateTime<Utc>>,
-    pub last_modified: Option<DateTime<Utc>>,
+pub struct AddedModifiedYears {
     pub original_path: PathBuf,
+    pub years: String,
 }
 
 pub async fn check_repo_copyright(repo_path_: &str, name: &str, config: &Config) {
     let repo_path = Path::new(repo_path_);
-    let repo = Repository::open(repo_path).expect("Could not open repository");
-    let files_to_check =
-        get_files_on_ref(&repo, "HEAD", repo_path_).expect("Could not get files on `HEAD`");
-    let files_to_check = config.filter_files(files_to_check.iter());
+    let files_to_check = get_files_on_ref(repo_path_, "HEAD")
+        .await
+        .expect("Could not get files on `HEAD`");
+    let files_to_check: Vec<&String> = config
+        .filter_files(files_to_check.iter())
+        .into_iter()
+        .filter(|f| repo_path.join(Path::new(f)).is_file())
+        .collect();
 
-    let mut add_mod_ranges = get_add_mod_ranges(&repo, files_to_check.iter().map(|x| *x)).unwrap();
-    let add_mod_map: HashMap<u64, AddedModifiedInfo> = add_mod_ranges
+    println!("Checking {} files", files_to_check.len());
+
+    let mut add_mod_years = get_add_mod_ranges(files_to_check.iter().map(|x| *x), repo_path_)
+        .await
+        .unwrap();
+    let add_mod_map: HashMap<u64, AddedModifiedYears> = add_mod_years
         .drain(..)
         .map(|am_info| (get_hash(&am_info.original_path.to_str().unwrap()), am_info))
         .collect();
@@ -54,16 +69,16 @@ pub async fn check_repo_copyright(repo_path_: &str, name: &str, config: &Config)
     let check_and_fix_futures: Vec<_> = files_to_check
         .iter()
         .map(|filepath| {
-            let years = get_years_info(filepath, &add_mod_map);
+            let years = &add_mod_map.get(&get_hash(filepath)).unwrap().years;
             let comment_sign = config
                 .get_comment_sign(filepath)
                 .expect(&format!("Could not get comment sign for {}", filepath));
-            let copyright_line = generate_copyright_line(name, comment_sign, &years);
+            let copyright_line = generate_copyright_line(name, comment_sign, years);
             let filepath = repo_path.join(filepath);
             check_and_fix_file(
                 filepath,
                 regex_cache.get_regex(comment_sign),
-                years,
+                years.clone(),
                 copyright_line,
             )
         })
@@ -76,23 +91,4 @@ pub fn get_hash<T: std::hash::Hash>(obj: &T) -> u64 {
     let mut hasher = DefaultHasher::new();
     obj.hash(&mut hasher);
     hasher.finish()
-}
-
-pub fn get_years_info(filepath: &str, add_mod_map: &HashMap<u64, AddedModifiedInfo>) -> String {
-    match add_mod_map.get(&get_hash(&filepath)) {
-        None => "UNKNOWN".to_owned(),
-        Some(am_info) => {
-            if am_info.added.is_none() || am_info.last_modified.is_none() {
-                "UNKNOWN".to_owned()
-            } else {
-                let added = am_info.added.unwrap().year().to_string();
-                let modified = am_info.last_modified.unwrap().year().to_string();
-                if added != modified {
-                    [added, modified].join("-").to_owned()
-                } else {
-                    added
-                }
-            }
-        }
-    }
 }


### PR DESCRIPTION
Using libgit2, there is no battle-proven way to follow the history of a
file through renames, see also:
https://github.com/libgit2/libgit2sharp/issues/893

Consequently, we are removing libgit2 as a dependency and instead rely
on the git binary, calling it in a subprocess.

Another change in this commit is switching from `(c) Copyright` to
`Copyright (c)`.