### PR TITLE
Refactor to async file processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "Add/update copyright notes based on git history"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license-file = "LICENSE-APACHE"
 name = "git_copyright"

--- a/src/file_ops.rs
+++ b/src/file_ops.rs
@@ -1,17 +1,21 @@
 //! Check and update copyright of file.
 
+use futures::join;
+use futures::Future;
 use regex::Regex;
 use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 use std::{path::Path, path::PathBuf};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-pub async fn check_and_fix_file(
+pub async fn read_write_copyright(
     filepath: PathBuf,
     regex: Arc<Regex>,
-    years: String,
-    copyright_line: String,
+    years_fut: impl Future<Output = String>,
+    copyright_line: impl Future<Output = String>,
 ) {
+    let (years, copyright_line) = join!(years_fut, copyright_line);
+
     // This could be re-written to read the file asynchronously until EOF or the first n
     // newlines are found.
     let file = std::fs::File::open(&filepath)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use clap::Parser;
 use env_logger::TimestampPrecision;
 use git_copyright::{check_repo_copyright, Config};
+use std::time::Instant;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -15,7 +16,7 @@ struct Args {
     #[clap(short, long)]
     name: String,
 
-    /// TOML file with config to use
+    /// YAML file with config to use
     #[clap(short, long, default_value = "")]
     config: String,
 }
@@ -39,5 +40,8 @@ async fn main() {
         }
     };
 
+    let start = Instant::now();
     check_repo_copyright(&args.repo, &args.name, &config).await;
+    let duration_s = start.elapsed().as_millis() as f32 / 1000.0;
+    println!("Finished in {:0.3}s", duration_s);
 }

--- a/src/regex_ops.rs
+++ b/src/regex_ops.rs
@@ -7,6 +7,7 @@ use super::get_hash;
 use super::CommentSign;
 use regex::Regex;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -49,11 +50,16 @@ pub fn generate_base_regex(name: &str) -> String {
     .join(" ")
 }
 
-pub fn generate_copyright_line(name: &str, comment_sign: &CommentSign, years: &str) -> String {
+pub async fn generate_copyright_line(
+    name: &str,
+    comment_sign: &CommentSign,
+    years_fut: impl Future<Output = String>,
+) -> String {
+    let years = years_fut.await;
     match comment_sign {
-        CommentSign::LeftOnly(ref left) => [left, "Copyright (c)", name, years].join(" "),
+        CommentSign::LeftOnly(ref left) => [left, "Copyright (c)", name, &years].join(" "),
         CommentSign::Enclosing(ref left, ref right) => {
-            [left, "Copyright (c)", name, years, right].join(" ")
+            [left, "Copyright (c)", name, &years, right].join(" ")
         }
     }
 }


### PR DESCRIPTION
Previously, we determined all added/modified times for all files first
and then checked/updated the copyrights of all files concurrently.
    
Now, we run the whole process of checking for added/modified times and
checking/updating of copyrights concurrently.