### PR TITLE
Allow failing if tracked files changed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "Add/update copyright notes based on git history"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license-file = "LICENSE-APACHE"
 name = "git_copyright"

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,9 @@ pub enum CError {
     #[error("Some copyrights could not be fixed, please check the output")]
     FixError,
 
+    #[error("The copyright job changed tracked files that should be committed")]
+    FilesChanged,
+
     #[error(transparent)]
     GenericIOError(#[from] std::io::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,10 @@ struct Args {
     /// YAML file with config to use
     #[clap(short, long, default_value = "")]
     config: String,
+
+    /// Do not fail even if tracked files changed
+    #[clap(short, long)]
+    ignore_changes: bool,
 }
 
 #[tokio::main]
@@ -44,7 +48,7 @@ async fn main() -> Result<()> {
     }
 
     let start = Instant::now();
-    check_repo_copyright(&args.repo, &args.name).await?;
+    check_repo_copyright(&args.repo, &args.name, !args.ignore_changes).await?;
     let duration_s = start.elapsed().as_millis() as f32 / 1000.0;
     println!("Copyrights checked and updated in {:0.3}s", duration_s);
 


### PR DESCRIPTION
When running the copyright check in CI, we might want to fail if any
tracked files were changed. This is now default behavior and has to be
opted out with `--ignore-changes`.