### PR TITLE
Add Dockerfile to build docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Things to ignore in the Docker build
+
+Cargo.lock
+Dockerfile
+.dockerignore
+.github
+.vscode

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,3 +38,23 @@ jobs:
         with:
           files: |
             *.tar.gz
+
+  docker_build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Set variables
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build docker image
+        run: docker build -f Dockerfile --tag "sgasse/git_copyright:${VERSION}" .
+
+      - name: Login to Docker
+        run: docker login -u sgasse -p ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push image
+        run: docker push "sgasse/git_copyright:${VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+
+FROM rust:alpine as builder_rust
+
+# Required in compiling some dependencies (at least proc-macro-error)
+RUN apk add build-base
+
+COPY ./ /repo
+WORKDIR /repo
+
+RUN cargo build --release
+
+FROM alpine/git
+
+COPY --from=builder_rust /repo/target/release/git_copyright /usr/bin/git_copyright
+
+WORKDIR /mnt
+
+ENTRYPOINT ["/usr/bin/git_copyright"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ A full command might look like this:
 git_copyright --name "MyCompany Ltd." --repo "../../my_repo" --config "./custom_cfg.yml" --ignore-changes
 ```
 
+### Run with Docker
+
+You can also use a pre-built image:
+
+```bash
+docker run --rm -u $(id -u) -v $(pwd):/mnt sgasse/git_copyright:0.2.7 --name "MyCompany Ltd."
+```
+
 ## Development
 
 When developing, you can set the log environment variable to see debug log output:


### PR DESCRIPTION
To keep the size small, we build on alpine and copy the compiled binary
into alpine/git (since we need git installed).